### PR TITLE
patch v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,11 @@ Extras:
 
 # Version Changes Control
 
+v1.8.0 - 2024-04-08
+-----------------------
+- Added GetConfig() in Datasource Interface so the xmodules can use Datasource interface as standard without casting
+- The various parts of xamboo-env, xamboo-master, xamboo-admin and xmodules have been modified to meet new normalized standard
+
 v1.7.7 - 2023-03-16
 -----------------------
 - Documentation enhanced with some new entries

--- a/applications/assets.go
+++ b/applications/assets.go
@@ -56,6 +56,7 @@ type DatasourceSet interface {
 type Datasource interface {
 	// general needed funcion
 	GetName() string
+	GetConfig() *xconfig.XConfig
 	AddLanguage(lang language.Tag)
 	GetLanguages() []language.Tag
 	SetLog(id string, logger *log.Logger)

--- a/xamboo.go
+++ b/xamboo.go
@@ -26,4 +26,4 @@
 package xamboo
 
 // VERSION last oficial published version of the xamboo on github.com
-const VERSION = "1.7.7"
+const VERSION = "1.8.0"


### PR DESCRIPTION
- Added GetConfig() in Datasource Interface so the xmodules can use Datasource interface as standard without casting
- The various parts of xamboo-env, xamboo-master, xamboo-admin and xmodules have been modified to meet new normalized standard
