### PR TITLE
patch v1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,6 +1566,10 @@ Extras:
 
 # Version Changes Control
 
+v1.8.2 - 2024-04-12
+-----------------------
+- Error corrected into config/config.go: when the config file had an error of reading/loading, the error was not reported (and system just panic sometimes after)
+
 v1.8.1 - 2024-04-10
 -----------------------
 - go.mod and go.sum modidied for security and up-to-date libraries updates

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,10 @@ func (c *ConfigDef) Load(file string) error {
 				lc := xconfig.New()
 				// adapt this to multiple config files. They are all replaced by default, consider + on parameters to merge them
 				for j := range c.Hosts[i].CMS.ConfigFiles {
-					lc.LoadFile(c.Hosts[i].CMS.ConfigFiles[j])
+					err := lc.LoadFile(c.Hosts[i].CMS.ConfigFiles[j])
+					if err != nil {
+						return err
+					}
 				}
 				c.Hosts[i].CMS.Config = lc
 			}

--- a/xamboo.go
+++ b/xamboo.go
@@ -26,4 +26,4 @@
 package xamboo
 
 // VERSION last oficial published version of the xamboo on github.com
-const VERSION = "1.8.1"
+const VERSION = "1.8.2"


### PR DESCRIPTION
- Error corrected into config/config.go: when the config file had an error of reading/loading, the error was not reported (and system just panic sometimes after)
